### PR TITLE
Replace reference to `clojure-sample` with `welcometoclojurebridge`

### DIFF
--- a/outline/setup_win8.md
+++ b/outline/setup_win8.md
@@ -97,7 +97,7 @@ Your terminal should look similar to this picture:
 
 Then run the command:
 
-`cd clojure-sample`
+`cd welcometoclojurebridge`
 
 This will put you in the directory with the source code for this sample bit of Clojure code. After that completes, run:
 


### PR DESCRIPTION
`clojure-sample` is the project from the main `ClojureBridge/curriculum` repo, whereas `welcometoclojurebridge` is the project that AustinClojure uses.